### PR TITLE
Fix failing Buildbot icon test

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,6 @@
 {
     "only-arches": [
         "x86_64"
-    ]
+    ],
+    "skip-icons-check": true
 }


### PR DESCRIPTION
Protontricks doesn't have an icon since it's not a graphical application, so skip the icon test to prevent the build from failing.