### PR TITLE
Install Perl

### DIFF
--- a/com.valvesoftware.Steam.Utility.protontricks.yml
+++ b/com.valvesoftware.Steam.Utility.protontricks.yml
@@ -13,7 +13,6 @@ build-options:
   prepend-ld-library-path: /app/utils/protontricks/lib
   env:
     PYTHONPATH: /app/utils/protontricks/lib/python3.8/site-packages
-  strip: true
 cleanup:
   - "*.a"
   - "*.la"
@@ -52,6 +51,8 @@ modules:
 
           - name: p7zip
             no-autogen: true
+            build-options:
+              strip: true
             make-args:
               - all2
               - OPTFLAGS=-O2 -g
@@ -93,6 +94,8 @@ modules:
                   - "*"
 
           - name: cabextract
+            build-options:
+              strip: true
             sources:
               - type: archive
                 url: "https://www.cabextract.org.uk/cabextract-1.9.1.tar.gz"
@@ -100,6 +103,8 @@ modules:
 
           - name: unrar
             no-autogen: true
+            build-options:
+              strip: true
             make-install-args:
               - DESTDIR=$(FLATPAK_DEST)
             sources:
@@ -109,6 +114,48 @@ modules:
 
           - name: binutils-ar
             buildsystem: simple
+            build-options:
+              strip: true
             build-commands:
               - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin/
               - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/
+
+          - name: perl
+            no-autogen: true
+            config-opts:
+              - "-des"
+            cleanup:
+              - "*.pod"
+              - "/bin/perl5*"
+              - "/bin/c2ph"
+              - "/bin/corelist"
+              - "/bin/cpan"
+              - "/bin/enc2xs"
+              - "/bin/encguess"
+              - "/bin/h2*"
+              - "/bin/instmodsh"
+              - "/bin/json_pp"
+              - "/bin/libnetcfg"
+              - "/bin/perlbug"
+              - "/bin/perldoc"
+              - "/bin/perlthanks"
+              - "/bin/piconv"
+              - "/bin/pl2pm"
+              - "/bin/pod*"
+              - "/bin/prove"
+              - "/bin/pstruct"
+              - "/bin/ptar*"
+              - "/bin/shasum"
+              - "/bin/splain"
+              - "/bin/xsubpp"
+              - "/bin/zipdetails"
+            sources:
+              - type: archive
+                url: "https://www.cpan.org/src/5.0/perl-5.32.0.tar.gz"
+                sha256: efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4
+              - type: script
+                dest-filename: configure
+                commands:
+                  - "exec ./configure.gnu $@"
+            post-install:
+              - "find ${FLATPAK_DEST}/lib/perl5 -type f -exec chmod u+w {} \\;"


### PR DESCRIPTION
Perl is now needed by Winetricks when parsing download progress, causing
failure with common use cases.

Fixes #21